### PR TITLE
Fix error for kubernetes version higher 1.20.x and upgrade version gatus 2.9.0 last version of v2

### DIFF
--- a/gatus/Chart.yaml
+++ b/gatus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gatus
 description: Automated service health dashboard
-version: 1.1.4
-appVersion: v2.7.0
+version: 1.1.5
+appVersion: v2.9.0
 type: application
 engine: gotpl
 home: https://avakarev.github.io/gatus-chart

--- a/gatus/templates/_helpers.tpl
+++ b/gatus/templates/_helpers.tpl
@@ -45,3 +45,18 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "gatus.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress
+*/}}
+{{- define "gatus.ingress.apiVersion" -}}
+{{- if .Values.apiVersionOverrides.ingress -}}
+{{- print .Values.apiVersionOverrides.ingress -}}
+{{- else if semverCompare "<1.14-0" (include "gatus.kubeVersion" $) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "gatus.kubeVersion" $) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/gatus/templates/ingress.yaml
+++ b/gatus/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "gatus.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "gatus.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/gatus/values.yaml
+++ b/gatus/values.yaml
@@ -10,7 +10,7 @@ livenessProbe:
 
 image:
   repository: twinproduction/gatus
-  tag: v2.7.0
+  tag: v2.9.0
   pullPolicy: IfNotPresent
 
   # Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
Hi,
My cluster kubernetes is version 1.21.3, and the version of the Ingress apiVersion in beta1 has been removed.

By the way, I take this opportunity to put the last version of the Gatus image for version 2