### PR TITLE
feature: import host trusted CA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Gatus version is upgraded from 2 to 3. Gatus 3 deprecates `memory` type of stora
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                       |
 | `image.pullSecrets`                       | Image pull secrets                            | `{}`                                 |
 | `hostNetwork.enabled`                     | Enable host network mode                      | `false`                              |
+| `hostCACertificates`                      | Use host CA trust store                       | `false`                              |
 | `annotations`                             | Deployment annotations                        | `{}`                                 |
 | `labels`                                  | Deployment labels                             | `{}`                                 |
 | `podAnnotations`                          | Pod annotations                               | `{}`                                 |

--- a/gatus/templates/_pod.tpl
+++ b/gatus/templates/_pod.tpl
@@ -59,6 +59,12 @@ containers:
         subPath: {{ .Values.persistence.subPath }}
         {{- end }}
       {{- end }}
+      {{- if .Values.hostCACertificates }}
+      - name: etc-ssl
+        mountPath: /etc/ssl
+      - name: etc-pki
+        mountPath: /etc/pki
+      {{- end }}
 volumes:
   - name: {{ template "gatus.fullname" . }}-config
     configMap:
@@ -67,6 +73,16 @@ volumes:
   - name: {{ template "gatus.fullname" . }}-data
     persistentVolumeClaim:
       claimName: {{ .Values.persistence.existingClaim | default (include "gatus.fullname" .) }}
+  {{- end }}
+  {{- if .Values.hostCACertificates }}
+  - name: etc-ssl
+    hostPath:
+      path: /etc/ssl
+      type: Directory
+  - name: etc-pki
+    hostPath:
+      path: /etc/pki
+      type: DirectoryOrCreate
   {{- end }}
 {{- with .Values.nodeSelector }}
 nodeSelector:

--- a/gatus/values.yaml
+++ b/gatus/values.yaml
@@ -27,6 +27,9 @@ image:
 hostNetwork:
   enabled: false
 
+# use host trust store in pod
+hostCACertificates: false
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
It is common for internal services to have HTTPS/TLS certificates signed by internal Certificate Authority. This authority CA certificate is typically added to the host system trust store.
Without access to the trust store, Gatus cannot monitor services secured with custom CA - because of error `x509: certificate signed by unknown authority`. 
Mounting host trusted cert store allows Gatus to utilize internal CA certificate for TLS validation.

Every Linux distribution comes with `/etc/ssl` directory where system trusted certificates reside. Some distributions (Fedora-based) ship only symlinks in `/etc/ssl`, with actual certificates in `/etc/pki`. As we have no way of detecting host distribution, we need to mount both paths.
